### PR TITLE
Fixes default heif-converter binary path

### DIFF
--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -180,7 +180,7 @@ class HeicToJpg {
     protected function tryToConvertWithLibheif(string $source, string $newFile): bool {
         // ./vendor/bin/heif-converter-linux heic input.heic output.png
         if (empty($this->libheifConverterLocation)) {
-            $this->libheifConverterLocation = __DIR__.'/../bin/' . "heif-converter-" . $this->os;
+            $this->libheifConverterLocation = dirname(__DIR__, 2) . '/heif-converter/bin/heif-converter-' . $this->os;
         }
         // If libheif converter is available, try to convert
         if (file_exists($this->libheifConverterLocation)) {


### PR DESCRIPTION
Fixes the default binary path for heif-converter to resolve to `{vendor_path}/heif-converter/bin` when not set explicitly.

We noticed the current default binary path doesn't exist. We were able to workaround this using the setConverterLocation() method, and confirmed this fix in our testing environment.